### PR TITLE
Set default class to `serialize`.

### DIFF
--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,3 +1,3 @@
 class Product < ApplicationRecord
-  serialize :serialized_column
+  serialize :serialized_column, ActiveSupport::HashWithIndifferentAccess
 end


### PR DESCRIPTION
This reproduces the `FormBuilder` issue discussed here: https://github.com/rails/rails/issues/46154.

With this change, inspecting the `fields_form.class` will yield the standard `ActionView::Helpers::FormBuilder` instead of the custom `CustomBuilder` as provided in the parent `form_for`:

```ruby
fields_form.class
#=> ActionView::Helpers::FormBuilder
```